### PR TITLE
Add index enhancements: call graph, modules, tags, clusters, data flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["hatchling"]
-build-backend = "hatchling.backends"
+build-backend = "hatchling.build"
 
 [project]
 name = "sigil"

--- a/src/sigil/cli.py
+++ b/src/sigil/cli.py
@@ -10,7 +10,7 @@ import click
 
 from sigil.format import now_iso
 from sigil.languages import get_adapter, supported_extensions
-from sigil.sidecar import Sidecar, drift_status, refresh_sidecar
+from sigil.sidecar import Sidecar, compute_called_by, drift_status, refresh_sidecar
 from sigil.store import _record_from_existing, find_project_root, is_ignored, _EXT_TO_LANG
 
 
@@ -45,14 +45,37 @@ def init(root: str) -> None:
                 if rec.symbol_id not in sidecar.data["symbols"]:
                     sidecar.upsert(rec.symbol_id, _record_from_existing(rel, rec, language))
                     n_new += 1
+    # Also populate module-level summaries.
+    n_modules = 0
+    for ext in exts:
+        for f in root_path.rglob(f"*{ext}"):
+            if is_ignored(f, root_path):
+                continue
+            rel = str(f.resolve().relative_to(root_path.resolve()))
+            adapter = get_adapter(f.suffix)
+            if adapter is None or not hasattr(adapter, "parse_module"):
+                continue
+            try:
+                mod_rec = adapter.parse_module(f, rel)
+                sidecar.data["modules"][rel] = {
+                    "language": mod_rec.language,
+                    "imports": mod_rec.imports,
+                    "exports": mod_rec.exports,
+                    "line_count": mod_rec.line_count,
+                }
+                n_modules += 1
+            except Exception:
+                continue
+
     sidecar.data["last_full_scan"] = now_iso()
     sidecar.save()
-    click.echo(f"snapshotted {n_new} symbols → {sidecar.path}")
+    click.echo(f"snapshotted {n_new} symbols, {n_modules} modules → {sidecar.path}")
 
 
 @cli.command(name="list")
 @click.option("--drifted", is_flag=True)
-def list_cmd(drifted: bool) -> None:
+@click.option("--tag", "filter_tag", default=None, help="Filter symbols by tag.")
+def list_cmd(drifted: bool, filter_tag: str | None) -> None:
     """List tracked symbols and their drift status."""
     root = find_project_root(Path("."))
     sidecar = Sidecar(root)
@@ -61,8 +84,12 @@ def list_cmd(drifted: bool) -> None:
         status = drift_status(rec)
         if drifted and status != "drifted":
             continue
+        if filter_tag and filter_tag not in rec.get("tags", []):
+            continue
         agent = rec.get("sigil_agent") or "-"
-        click.echo(f"{status:10s} {sid}  ({agent})")
+        tags = rec.get("tags", [])
+        tag_str = f"  [{', '.join(tags)}]" if tags else ""
+        click.echo(f"{status:10s} {sid}  ({agent}){tag_str}")
 
 
 @cli.command()
@@ -92,7 +119,157 @@ def show(symbol_id: str) -> None:
     if not rec:
         click.echo(f"no record: {symbol_id}", err=True)
         sys.exit(2)
-    click.echo(json.dumps(rec, indent=2, sort_keys=True))
+    # Attach called_by for display.
+    called_by = compute_called_by(sidecar.data["symbols"])
+    display = dict(rec)
+    if symbol_id in called_by:
+        display["called_by"] = called_by[symbol_id]
+    click.echo(json.dumps(display, indent=2, sort_keys=True))
+
+
+@cli.command()
+@click.argument("symbol_id")
+def graph(symbol_id: str) -> None:
+    """Show call graph for a symbol: what it calls and what calls it."""
+    root = find_project_root(Path("."))
+    sidecar = Sidecar(root)
+    refresh_sidecar(root, sidecar)
+    symbols = sidecar.data["symbols"]
+    rec = symbols.get(symbol_id)
+    if not rec:
+        click.echo(f"no record: {symbol_id}", err=True)
+        sys.exit(2)
+
+    called_by = compute_called_by(symbols)
+
+    calls = rec.get("calls", [])
+    callers = called_by.get(symbol_id, [])
+
+    click.echo(f"Symbol: {symbol_id}")
+    click.echo(f"\nCalls ({len(calls)}):")
+    for c in calls:
+        click.echo(f"  → {c}")
+    click.echo(f"\nCalled by ({len(callers)}):")
+    for c in callers:
+        click.echo(f"  ← {c}")
+
+
+@cli.command()
+@click.argument("symbol_id")
+@click.argument("tags", nargs=-1, required=True)
+@click.option("--remove", is_flag=True, help="Remove tags instead of adding.")
+def tag(symbol_id: str, tags: tuple[str, ...], remove: bool) -> None:
+    """Add or remove tags on a symbol. Usage: sig tag <symbol> tag1 tag2 ..."""
+    root = find_project_root(Path("."))
+    sidecar = Sidecar(root)
+    rec = sidecar.data["symbols"].get(symbol_id)
+    if not rec:
+        click.echo(f"no record: {symbol_id}", err=True)
+        sys.exit(2)
+    current = set(rec.get("tags", []))
+    if remove:
+        current -= set(tags)
+    else:
+        current |= set(tags)
+    rec["tags"] = sorted(current)
+    sidecar.save()
+    click.echo(f"{symbol_id}: tags={rec['tags']}")
+
+
+@cli.command()
+@click.argument("symbol_id")
+@click.option("--reads", multiple=True, help="Resources this function reads from.")
+@click.option("--writes", multiple=True, help="Resources this function writes to.")
+@click.option("--clear", is_flag=True, help="Clear all data flow annotations.")
+def annotate(symbol_id: str, reads: tuple[str, ...], writes: tuple[str, ...], clear: bool) -> None:
+    """Annotate a symbol with data flow info (reads/writes).
+
+    Examples:
+      sig annotate myfile.py::load_config --reads config.yaml --reads .env
+      sig annotate myfile.py::save_results --writes runs/metadata.json
+    """
+    root = find_project_root(Path("."))
+    sidecar = Sidecar(root)
+    rec = sidecar.data["symbols"].get(symbol_id)
+    if not rec:
+        click.echo(f"no record: {symbol_id}", err=True)
+        sys.exit(2)
+
+    if clear:
+        rec.pop("reads", None)
+        rec.pop("writes", None)
+        sidecar.save()
+        click.echo(f"{symbol_id}: data flow annotations cleared")
+        return
+
+    if not reads and not writes:
+        # Display current annotations.
+        r = rec.get("reads", [])
+        w = rec.get("writes", [])
+        click.echo(f"{symbol_id}")
+        click.echo(f"  reads:  {', '.join(r) if r else '(none)'}")
+        click.echo(f"  writes: {', '.join(w) if w else '(none)'}")
+        return
+
+    # Merge with existing.
+    existing_reads = set(rec.get("reads", []))
+    existing_writes = set(rec.get("writes", []))
+    existing_reads |= set(reads)
+    existing_writes |= set(writes)
+    rec["reads"] = sorted(existing_reads)
+    rec["writes"] = sorted(existing_writes)
+    sidecar.save()
+    click.echo(f"{symbol_id}")
+    click.echo(f"  reads:  {', '.join(rec['reads'])}")
+    click.echo(f"  writes: {', '.join(rec['writes'])}")
+
+
+@cli.command()
+@click.option("--min-cooccurrence", default=2, type=int, help="Min co-modification count.")
+@click.option("--json-output", "json_out", is_flag=True, help="Output as JSON.")
+def clusters(min_cooccurrence: int, json_out: bool) -> None:
+    """Show functions that are frequently modified together in commits."""
+    from sigil.clusters import compute_clusters
+
+    root = find_project_root(Path("."))
+    sidecar = Sidecar(root)
+    result = compute_clusters(root, sidecar.data["symbols"], min_cooccurrence=min_cooccurrence)
+    if not result:
+        click.echo("no change clusters found (need git history with multiple co-modified files)")
+        sys.exit(0)
+    if json_out:
+        click.echo(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for sid, partners in sorted(result.items()):
+            click.echo(f"{sid}")
+            for p in partners[:5]:
+                click.echo(f"  ↔ {p}")
+            if len(partners) > 5:
+                click.echo(f"  ... and {len(partners) - 5} more")
+
+
+@cli.command()
+@click.option("--json-output", "json_out", is_flag=True, help="Output as JSON.")
+def modules(json_out: bool) -> None:
+    """List module-level summaries (imports, exports, line counts)."""
+    root = find_project_root(Path("."))
+    sidecar = Sidecar(root)
+    mods = sidecar.data.get("modules", {})
+    if not mods:
+        click.echo("no modules indexed — run `sig init` first")
+        sys.exit(0)
+    if json_out:
+        click.echo(json.dumps(mods, indent=2, sort_keys=True))
+    else:
+        for rel, info in sorted(mods.items()):
+            exports = info.get("exports", [])
+            imports = info.get("imports", [])
+            lines = info.get("line_count", 0)
+            click.echo(f"{rel}  ({info.get('language', '?')}, {lines} lines)")
+            if exports:
+                click.echo(f"  exports: {', '.join(exports[:10])}")
+            if imports:
+                click.echo(f"  imports: {', '.join(imports[:10])}")
 
 
 @cli.group()

--- a/src/sigil/clusters.py
+++ b/src/sigil/clusters.py
@@ -1,0 +1,80 @@
+"""Change clusters: find functions that are frequently co-modified in commits."""
+
+from __future__ import annotations
+
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+
+def _git_log_file_groups(root: Path, max_commits: int = 500) -> list[list[str]]:
+    """Get lists of files changed together per commit from git log."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--name-only", "--pretty=format:", f"-{max_commits}"],
+            cwd=root, capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    groups: list[list[str]] = []
+    current: list[str] = []
+    for line in result.stdout.split("\n"):
+        line = line.strip()
+        if not line:
+            if current:
+                groups.append(current)
+                current = []
+        else:
+            current.append(line)
+    if current:
+        groups.append(current)
+    return groups
+
+
+def compute_clusters(root: Path, symbols: dict, min_cooccurrence: int = 2) -> dict[str, list[str]]:
+    """Find symbols that are frequently modified together.
+
+    Returns a dict mapping symbol_id → list of co-modified symbol_ids,
+    sorted by frequency (most frequent first).
+    """
+    # Map files to their symbols.
+    file_to_symbols: dict[str, list[str]] = {}
+    for sid, rec in symbols.items():
+        f = rec.get("file", "")
+        file_to_symbols.setdefault(f, []).append(sid)
+
+    # Count co-occurrences: how often each pair of symbols' files appear in the same commit.
+    pair_counts: Counter[tuple[str, str]] = Counter()
+    file_groups = _git_log_file_groups(root)
+
+    for files in file_groups:
+        # Only consider tracked files.
+        tracked = [f for f in files if f in file_to_symbols]
+        if len(tracked) < 2:
+            continue
+        # Count all symbol pairs across co-modified files.
+        all_syms: list[str] = []
+        for f in tracked:
+            all_syms.extend(file_to_symbols[f])
+        # Count pairs.
+        for i, a in enumerate(all_syms):
+            for b in all_syms[i + 1:]:
+                pair = (min(a, b), max(a, b))
+                pair_counts[pair] += 1
+
+    # Build clusters: for each symbol, list co-modified symbols above threshold.
+    clusters: dict[str, list[str]] = {}
+    for (a, b), count in pair_counts.items():
+        if count >= min_cooccurrence:
+            clusters.setdefault(a, []).append((count, b))
+            clusters.setdefault(b, []).append((count, a))
+
+    # Sort by frequency descending.
+    return {
+        sid: [s for _, s in sorted(partners, reverse=True)]
+        for sid, partners in clusters.items()
+    }

--- a/src/sigil/languages/base.py
+++ b/src/sigil/languages/base.py
@@ -12,11 +12,22 @@ from sigil.format import format_sigil_line, parse_sigil_line
 
 
 @dataclass
+class ModuleRecord:
+    """Per-file summary extracted at index time."""
+    file: str
+    language: str
+    imports: list[str]       # imported module names
+    exports: list[str]       # top-level symbol names defined in this file
+    line_count: int
+
+
+@dataclass
 class FunctionRecord:
     symbol_id: str
     body_hash: str
     line_range: tuple[int, int]
     existing_sigil: Optional[dict]
+    calls: list[str] | None = None  # list of called symbol names (unresolved)
 
 
 @runtime_checkable
@@ -26,6 +37,57 @@ class LanguageAdapter(Protocol):
 
     def parse(self, path: Path, rel_path: str) -> list[FunctionRecord]: ...
     def write_sigils(self, path: Path, rel_path: str, sigils: dict[str, str]) -> None: ...
+
+
+def treesitter_parse_module(path: Path, rel_path: str, language: str,
+                            parser, export_node_types: list[str],
+                            import_node_types: list[str]) -> ModuleRecord:
+    """Shared module-level info extraction for tree-sitter adapters."""
+    source = path.read_text(encoding="utf-8")
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    root = tree.root_node
+
+    imports: list[str] = []
+    exports: list[str] = []
+
+    def _walk_top_level(node):
+        for child in node.children:
+            # Imports
+            if child.type in import_node_types:
+                _extract_import(child, imports)
+            # Exports
+            if child.type in export_node_types:
+                name_node = child.child_by_field_name("name")
+                if name_node:
+                    exports.append(name_node.text.decode())
+            # Recurse into export statements
+            if child.type == "export_statement":
+                _walk_top_level(child)
+
+    def _extract_import(node, out: list[str]):
+        src = node.child_by_field_name("source") or node.child_by_field_name("path")
+        if src:
+            out.append(src.text.decode().strip("'\""))
+        else:
+            # For Go/Rust: import path is in the text
+            for c in node.children:
+                if c.type in ("interpreted_string_literal", "string_literal"):
+                    out.append(c.text.decode().strip("'\""))
+                elif c.type == "import_spec_list":
+                    for spec in c.children:
+                        if spec.type == "import_spec":
+                            path_node = spec.child_by_field_name("path")
+                            if path_node:
+                                out.append(path_node.text.decode().strip("'\""))
+
+    _walk_top_level(root)
+    line_count = source.count("\n") + 1
+    return ModuleRecord(
+        file=rel_path, language=language,
+        imports=sorted(set(imports)), exports=sorted(set(exports)),
+        line_count=line_count,
+    )
 
 
 def treesitter_write_sigils(path: Path, sigils: dict[str, str], comment_prefix: str,

--- a/src/sigil/languages/go.py
+++ b/src/sigil/languages/go.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sigil.format import compute_hash, parse_sigil_line
-from sigil.languages.base import FunctionRecord, treesitter_write_sigils
+from sigil.languages.base import FunctionRecord, ModuleRecord, treesitter_parse_module, treesitter_write_sigils
 
 _parser = None
 
@@ -56,6 +56,38 @@ def _walk_functions(node, rel_path: str, source_bytes: bytes, source_lines: list
             _record_function(child, func_name, rel_path, source_lines, records)
 
 
+def _collect_calls(node) -> list[str]:
+    """Collect function call names from a Go tree-sitter node."""
+    calls: list[str] = []
+    _walk_calls(node, calls)
+    return sorted(set(calls))
+
+
+def _walk_calls(node, calls: list[str]) -> None:
+    if node.type == "call_expression":
+        func_node = node.child_by_field_name("function")
+        if func_node:
+            name = _go_call_name(func_node)
+            if name:
+                calls.append(name)
+    for child in node.children:
+        _walk_calls(child, calls)
+
+
+def _go_call_name(node) -> str | None:
+    if node.type == "identifier":
+        return node.text.decode()
+    if node.type == "selector_expression":
+        field = node.child_by_field_name("field")
+        operand = node.child_by_field_name("operand")
+        if field and operand:
+            parent = _go_call_name(operand)
+            if parent:
+                return f"{parent}.{field.text.decode()}"
+            return field.text.decode()
+    return None
+
+
 def _record_function(node, func_name: str, rel_path: str,
                      source_lines: list[str], records: list[FunctionRecord]) -> None:
     symbol_id = f"{rel_path}::{func_name}"
@@ -68,7 +100,8 @@ def _record_function(node, func_name: str, rel_path: str,
         existing = parse_sigil_line(source_lines[start_line - 1])
 
     line_range = (start_line + 1, node.end_point[0] + 1)
-    records.append(FunctionRecord(symbol_id, h, line_range, existing))
+    calls = _collect_calls(node)
+    records.append(FunctionRecord(symbol_id, h, line_range, existing, calls=calls))
 
 
 class GoAdapter:
@@ -84,6 +117,14 @@ class GoAdapter:
         records: list[FunctionRecord] = []
         _walk_functions(tree.root_node, rel_path, source_bytes, source_lines, records)
         return records
+
+    def parse_module(self, path: Path, rel_path: str) -> ModuleRecord:
+        parser = _get_parser()
+        return treesitter_parse_module(
+            path, rel_path, "go", parser,
+            export_node_types=["function_declaration", "method_declaration", "type_declaration"],
+            import_node_types=["import_declaration"],
+        )
 
     def write_sigils(self, path: Path, rel_path: str, sigils: dict[str, str]) -> None:
         treesitter_write_sigils(path, sigils, self.comment_prefix, self.parse, rel_path)

--- a/src/sigil/languages/python.py
+++ b/src/sigil/languages/python.py
@@ -8,7 +8,36 @@ from pathlib import Path
 import libcst as cst
 
 from sigil.format import compute_hash, parse_sigil_line
-from sigil.languages.base import FunctionRecord
+from sigil.languages.base import FunctionRecord, ModuleRecord
+
+
+def _collect_calls_from_node(node: cst.CSTNode) -> list[str]:
+    """Recursively collect function call names from a libcst node."""
+    calls: list[str] = []
+    _walk_cst_calls(node, calls)
+    return sorted(set(calls))
+
+
+def _walk_cst_calls(node: cst.CSTNode, calls: list[str]) -> None:
+    """Walk libcst tree to find Call nodes."""
+    if isinstance(node, cst.Call):
+        name = _extract_call_name(node.func)
+        if name:
+            calls.append(name)
+    for child in node.children:
+        _walk_cst_calls(child, calls)
+
+
+def _extract_call_name(node: cst.BaseExpression) -> str | None:
+    """Extract a dotted call name from a Call func node."""
+    if isinstance(node, cst.Name):
+        return node.value
+    if isinstance(node, cst.Attribute):
+        parent = _extract_call_name(node.value)
+        if parent:
+            return f"{parent}.{node.attr.value}"
+        return node.attr.value
+    return None
 
 
 class _Visitor(cst.CSTVisitor):
@@ -44,7 +73,10 @@ class _Visitor(cst.CSTVisitor):
         pos = self.get_metadata(cst.metadata.PositionProvider, node)
         line_range = (pos.start.line, pos.end.line)
 
-        self.records.append(FunctionRecord(symbol_id, h, line_range, existing))
+        # Collect calls within the function body.
+        calls = _collect_calls_from_node(node.body)
+
+        self.records.append(FunctionRecord(symbol_id, h, line_range, existing, calls=calls))
         self.scope.append(node.name.value)
 
     def leave_FunctionDef(self, original_node: cst.FunctionDef) -> None:
@@ -90,6 +122,47 @@ class _Updater(cst.CSTTransformer):
         return updated_node.with_changes(leading_lines=tuple(new_leading))
 
 
+def _extract_python_module_info(module: cst.Module, source: str, rel_path: str) -> ModuleRecord:
+    """Extract module-level info: imports and top-level exports."""
+    imports: list[str] = []
+    exports: list[str] = []
+
+    for stmt in module.body:
+        # Unwrap simple statements
+        node = stmt
+        if isinstance(node, cst.SimpleStatementLine):
+            for item in node.body:
+                if isinstance(item, cst.Import):
+                    if isinstance(item.names, cst.ImportStar):
+                        imports.append("*")
+                    elif isinstance(item.names, (list, tuple)):
+                        for alias in item.names:
+                            imports.append(cst.Module(body=[]).code_for_node(alias.name).strip())
+                elif isinstance(item, cst.ImportFrom):
+                    mod = cst.Module(body=[]).code_for_node(item.module).strip() if item.module else ""
+                    if mod:
+                        imports.append(mod)
+                elif isinstance(item, (cst.Assign, cst.AnnAssign)):
+                    if isinstance(item, cst.Assign):
+                        for target in item.targets:
+                            if isinstance(target.target, cst.Name):
+                                exports.append(target.target.value)
+                    elif isinstance(item, cst.AnnAssign) and isinstance(item.target, cst.Name):
+                        exports.append(item.target.value)
+        elif isinstance(node, cst.FunctionDef):
+            exports.append(node.name.value)
+        elif isinstance(node, cst.ClassDef):
+            exports.append(node.name.value)
+
+    line_count = source.count("\n") + 1
+    lang = "python"
+    return ModuleRecord(
+        file=rel_path, language=lang,
+        imports=sorted(set(imports)), exports=sorted(set(exports)),
+        line_count=line_count,
+    )
+
+
 class PythonAdapter:
     comment_prefix: str = "#"
     extensions: tuple[str, ...] = (".py",)
@@ -101,6 +174,11 @@ class PythonAdapter:
         visitor = _Visitor(rel_path)
         wrapper.visit(visitor)
         return visitor.records
+
+    def parse_module(self, path: Path, rel_path: str) -> ModuleRecord:
+        source = path.read_text(encoding="utf-8")
+        module = cst.parse_module(source)
+        return _extract_python_module_info(module, source, rel_path)
 
     def write_sigils(self, path: Path, rel_path: str, sigils: dict[str, str]) -> None:
         if not sigils:

--- a/src/sigil/languages/rust.py
+++ b/src/sigil/languages/rust.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sigil.format import compute_hash, parse_sigil_line
-from sigil.languages.base import FunctionRecord, treesitter_write_sigils
+from sigil.languages.base import FunctionRecord, ModuleRecord, treesitter_parse_module, treesitter_write_sigils
 
 _parser = None
 
@@ -17,6 +17,40 @@ def _get_parser():
         from tree_sitter import Language, Parser
         _parser = Parser(Language(tsrs.language()))
     return _parser
+
+
+def _collect_calls(node) -> list[str]:
+    """Collect function call names from a Rust tree-sitter node."""
+    calls: list[str] = []
+    _walk_calls(node, calls)
+    return sorted(set(calls))
+
+
+def _walk_calls(node, calls: list[str]) -> None:
+    if node.type == "call_expression":
+        func_node = node.child_by_field_name("function")
+        if func_node:
+            name = _rust_call_name(func_node)
+            if name:
+                calls.append(name)
+    for child in node.children:
+        _walk_calls(child, calls)
+
+
+def _rust_call_name(node) -> str | None:
+    if node.type == "identifier":
+        return node.text.decode()
+    if node.type == "field_expression":
+        field = node.child_by_field_name("field")
+        value = node.child_by_field_name("value")
+        if field and value:
+            parent = _rust_call_name(value)
+            if parent:
+                return f"{parent}.{field.text.decode()}"
+            return field.text.decode()
+    if node.type == "scoped_identifier":
+        return node.text.decode().replace("::", ".")
+    return None
 
 
 def _walk_functions(node, rel_path: str, source_lines: list[str],
@@ -49,7 +83,8 @@ def _walk_functions(node, rel_path: str, source_lines: list[str],
                 existing = parse_sigil_line(source_lines[start_line - 1])
 
             line_range = (start_line + 1, child.end_point[0] + 1)
-            records.append(FunctionRecord(symbol_id, h, line_range, existing))
+            calls = _collect_calls(child)
+            records.append(FunctionRecord(symbol_id, h, line_range, existing, calls=calls))
             continue
 
         # Recurse into declaration_list (impl body), mod_item, etc.
@@ -70,6 +105,15 @@ class RustAdapter:
         records: list[FunctionRecord] = []
         _walk_functions(tree.root_node, rel_path, source_lines, [], records)
         return records
+
+    def parse_module(self, path: Path, rel_path: str) -> ModuleRecord:
+        parser = _get_parser()
+        return treesitter_parse_module(
+            path, rel_path, "rust", parser,
+            export_node_types=["function_item", "struct_item", "enum_item",
+                               "trait_item", "impl_item", "type_item"],
+            import_node_types=["use_declaration"],
+        )
 
     def write_sigils(self, path: Path, rel_path: str, sigils: dict[str, str]) -> None:
         treesitter_write_sigils(path, sigils, self.comment_prefix, self.parse, rel_path)

--- a/src/sigil/languages/typescript.py
+++ b/src/sigil/languages/typescript.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sigil.format import compute_hash, parse_sigil_line
-from sigil.languages.base import FunctionRecord, treesitter_write_sigils
+from sigil.languages.base import FunctionRecord, ModuleRecord, treesitter_parse_module, treesitter_write_sigils
 
 # Lazy-loaded parsers.
 _js_parser = None
@@ -80,6 +80,40 @@ def _walk_functions(node, rel_path: str, source_bytes: bytes, source_lines: list
             _walk_functions(child, rel_path, source_bytes, source_lines, scope, records)
 
 
+def _collect_calls(node) -> list[str]:
+    """Recursively collect function call names from a tree-sitter node."""
+    calls: list[str] = []
+    _walk_calls(node, calls)
+    return sorted(set(calls))
+
+
+def _walk_calls(node, calls: list[str]) -> None:
+    """Walk tree-sitter AST to find call_expression nodes."""
+    if node.type == "call_expression":
+        func_node = node.child_by_field_name("function")
+        if func_node:
+            name = _ts_call_name(func_node)
+            if name:
+                calls.append(name)
+    for child in node.children:
+        _walk_calls(child, calls)
+
+
+def _ts_call_name(node) -> str | None:
+    """Extract call name from a call_expression function node."""
+    if node.type == "identifier":
+        return node.text.decode()
+    if node.type == "member_expression":
+        prop = node.child_by_field_name("property")
+        obj = node.child_by_field_name("object")
+        if prop and obj:
+            parent = _ts_call_name(obj)
+            if parent:
+                return f"{parent}.{prop.text.decode()}"
+            return prop.text.decode()
+    return None
+
+
 def _record_function(node, func_name: str, rel_path: str, source_bytes: bytes,
                      source_lines: list[str], scope: list[str],
                      records: list[FunctionRecord]) -> None:
@@ -98,7 +132,8 @@ def _record_function(node, func_name: str, rel_path: str, source_bytes: bytes,
         existing = parse_sigil_line(above)
 
     line_range = (start_line + 1, node.end_point[0] + 1)  # 1-based
-    records.append(FunctionRecord(symbol_id, h, line_range, existing))
+    calls = _collect_calls(node)
+    records.append(FunctionRecord(symbol_id, h, line_range, existing, calls=calls))
 
 
 class TypeScriptAdapter:
@@ -114,6 +149,16 @@ class TypeScriptAdapter:
         records: list[FunctionRecord] = []
         _walk_functions(tree.root_node, rel_path, source_bytes, source_lines, [], records)
         return records
+
+    def parse_module(self, path: Path, rel_path: str) -> ModuleRecord:
+        parser = _get_parser(path.suffix)
+        lang = "typescript" if path.suffix in (".ts", ".tsx") else "javascript"
+        return treesitter_parse_module(
+            path, rel_path, lang, parser,
+            export_node_types=["function_declaration", "class_declaration",
+                               "lexical_declaration", "variable_declaration"],
+            import_node_types=["import_statement"],
+        )
 
     def write_sigils(self, path: Path, rel_path: str, sigils: dict[str, str]) -> None:
         treesitter_write_sigils(path, sigils, self.comment_prefix, self.parse, rel_path)

--- a/src/sigil/sidecar.py
+++ b/src/sigil/sidecar.py
@@ -18,8 +18,10 @@ class Sidecar:
 
     def _load(self) -> dict:
         if self.path.exists():
-            return json.loads(self.path.read_text(encoding="utf-8"))
-        return {"version": "0.1", "project_root": str(self.root), "last_full_scan": None, "symbols": {}}
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            data.setdefault("modules", {})
+            return data
+        return {"version": "0.1", "project_root": str(self.root), "last_full_scan": None, "symbols": {}, "modules": {}}
 
     def save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -37,6 +39,57 @@ def drift_status(record: dict) -> str:
     if record.get("body_hash") is None:
         return "orphaned"
     return "synced" if record.get("sigil_hash") == record.get("body_hash") else "drifted"
+
+
+# Standard layer vocabulary for auto-inference from file paths.
+_LAYER_PATTERNS: list[tuple[str, list[str]]] = [
+    ("api",        ["api/", "routes/", "endpoints/", "views/", "handlers/", "controllers/"]),
+    ("cli",        ["cli/", "cli.py", "commands/", "cmd/"]),
+    ("storage",    ["store/", "storage/", "db/", "database/", "models/", "repo/", "repository/"]),
+    ("validation", ["validation/", "validators/", "schemas/", "schema/"]),
+    ("config",     ["config/", "settings/", "conf/"]),
+    ("test",       ["test/", "tests/", "test_", "_test.", "spec/", ".test.", ".spec."]),
+    ("hook",       ["hook/", "hooks/", "hook.py", "hooks.py"]),
+    ("format",     ["format/", "format.py", "formatting/", "serialization/"]),
+    ("language",   ["languages/", "lang/", "parsers/", "adapters/"]),
+]
+
+
+def infer_tags(file_path: str) -> list[str]:
+    """Infer semantic layer tags from a file's path."""
+    lower = file_path.lower()
+    tags = []
+    for layer, patterns in _LAYER_PATTERNS:
+        for pat in patterns:
+            if pat in lower:
+                tags.append(layer)
+                break
+    return sorted(set(tags))
+
+
+def compute_called_by(symbols: dict) -> dict[str, list[str]]:
+    """Build a reverse index: symbol_id → list of symbol_ids that call it."""
+    # Build a map of short name → list of full symbol_ids for resolution.
+    name_to_sids: dict[str, list[str]] = {}
+    for sid in symbols:
+        # "file.py::Class.method" → "method", "Class.method"
+        _, _, qual = sid.partition("::")
+        parts = qual.split(".")
+        for i in range(len(parts)):
+            short = ".".join(parts[i:])
+            name_to_sids.setdefault(short, []).append(sid)
+
+    called_by: dict[str, list[str]] = {}
+    for sid, rec in symbols.items():
+        for call_name in rec.get("calls", []):
+            # Try to resolve call_name to known symbol_ids.
+            targets = name_to_sids.get(call_name, [])
+            for target in targets:
+                if target != sid:
+                    called_by.setdefault(target, []).append(sid)
+
+    # Deduplicate and sort.
+    return {k: sorted(set(v)) for k, v in called_by.items()}
 
 
 def refresh_sidecar(root: Path, sidecar: Sidecar) -> None:

--- a/src/sigil/store.py
+++ b/src/sigil/store.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from sigil.format import format_sigil_line, now_iso
 from sigil.languages import get_adapter
 from sigil.languages.base import FunctionRecord
-from sigil.sidecar import SIDECAR_DIR, Sidecar
+from sigil.sidecar import SIDECAR_DIR, Sidecar, infer_tags
 
 DEFAULT_IGNORE_DIRS = {".git", ".venv", "venv", "__pycache__", "node_modules", "dist", "build", ".sigil"}
 
@@ -27,7 +27,7 @@ def is_ignored(path: Path, root: Path) -> bool:
 
 def _record_from_existing(rel: str, rec: FunctionRecord, language: str) -> dict:
     bc = rec.existing_sigil
-    return {
+    result = {
         "file": rel,
         "language": language,
         "line_range": list(rec.line_range),
@@ -38,6 +38,10 @@ def _record_from_existing(rel: str, rec: FunctionRecord, language: str) -> dict:
         "sigil_agent": bc["agent_id"] if bc else None,
         "sigil_timestamp": bc["timestamp"] if bc else None,
     }
+    if rec.calls is not None:
+        result["calls"] = rec.calls
+    result["tags"] = infer_tags(rel)
+    return result
 
 
 # Map extensions to language names for sidecar records.
@@ -75,7 +79,7 @@ def update_for_file(root: Path, file_path: Path, agent_id: str, stamp_new: bool 
                 role = rec.symbol_id.split("::", 1)[1].split(".")[-1]
                 line_text = format_sigil_line(rec.body_hash, role, agent_id, ts, prefix=adapter.comment_prefix)
                 sigils_to_write[rec.symbol_id] = line_text
-                sidecar.upsert(rec.symbol_id, {
+                entry = {
                     "file": rel,
                     "language": language,
                     "line_range": list(rec.line_range),
@@ -85,7 +89,11 @@ def update_for_file(root: Path, file_path: Path, agent_id: str, stamp_new: bool 
                     "sigil_role": role,
                     "sigil_agent": agent_id,
                     "sigil_timestamp": ts,
-                })
+                }
+                if rec.calls is not None:
+                    entry["calls"] = rec.calls
+                entry["tags"] = infer_tags(rel)
+                sidecar.upsert(rec.symbol_id, entry)
                 summary["stamped"].append(rec.symbol_id)
             else:
                 sidecar.upsert(rec.symbol_id, _record_from_existing(rel, rec, language))
@@ -101,7 +109,7 @@ def update_for_file(root: Path, file_path: Path, agent_id: str, stamp_new: bool 
         line_text = format_sigil_line(rec.body_hash, role, agent_id, ts, prefix=adapter.comment_prefix)
         sigils_to_write[rec.symbol_id] = line_text
 
-        sidecar.upsert(rec.symbol_id, {
+        entry = {
             "file": rel,
             "language": language,
             "line_range": list(rec.line_range),
@@ -111,7 +119,14 @@ def update_for_file(root: Path, file_path: Path, agent_id: str, stamp_new: bool 
             "sigil_role": role,
             "sigil_agent": agent_id,
             "sigil_timestamp": ts,
-        })
+        }
+        if rec.calls is not None:
+            entry["calls"] = rec.calls
+        # Preserve user-set tags, merge with auto-inferred.
+        existing_tags = prev.get("tags", [])
+        auto_tags = infer_tags(rel)
+        entry["tags"] = sorted(set(existing_tags + auto_tags))
+        sidecar.upsert(rec.symbol_id, entry)
         summary["stamped"].append(rec.symbol_id)
 
     if sigils_to_write:


### PR DESCRIPTION
## Summary
Implements all five sigil index enhancement features from issues #1-#5:

- **Call graph edges (#1)**: Extract function calls from AST at index time, store `calls` per symbol, compute `called_by` as reverse index. New `sig graph <symbol>` command.
- **Module-level summaries (#5)**: Per-file entries with imports, exports, line counts. New `sig modules` command.
- **Semantic layer/tag annotations (#2)**: Auto-infer tags from file paths. Manual `sig tag`. Filter with `sig list --tag`.
- **Change clusters (#3)**: Git log co-modification analysis. New `sig clusters` command.
- **Data flow annotations (#4)**: Manual reads/writes via `sig annotate`.

Also fixes `pyproject.toml` build-backend (`hatchling.backends` → `hatchling.build`).

## Test plan
- [x] `sig init` populates calls, tags, and module summaries
- [x] `sig graph` shows calls and called_by correctly
- [x] `sig modules` lists per-file imports/exports
- [x] `sig list --tag <tag>` filters by tag
- [x] `sig tag` adds/removes manual tags
- [x] `sig clusters` finds co-modified functions from git history
- [x] `sig annotate` stores and displays reads/writes
- [x] `sig show` includes called_by and data flow info

🤖 Generated with [Claude Code](https://claude.com/claude-code)